### PR TITLE
Implement redis bus adapter

### DIFF
--- a/magent2/bus/redis_adapter.py
+++ b/magent2/bus/redis_adapter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Iterable
+from typing import Any
+
+from .interface import Bus, BusMessage
+
+
+class RedisBus(Bus):
+    """Redis Streams-backed Bus adapter.
+
+    - publish: XADD to stream named by topic
+    - read (no group): tail via XRANGE/XREVRANGE, supports last_id (uuid or entry id)
+    - read (group set): XREADGROUP with safe group creation and XACK after read
+    """
+
+    def __init__(
+        self,
+        redis_url: str | None = None,
+        *,
+        group_name: str | None = None,
+        consumer_name: str | None = None,
+        client: Any | None = None,
+    ) -> None:
+        try:
+            import redis
+        except Exception as exc:  # pragma: no cover - import-time error path
+            raise RuntimeError("redis package is required for RedisBus") from exc
+
+        url = redis_url or os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        if client is not None:
+            self._redis = client
+        else:
+            # decode_responses=True returns str everywhere for easier JSON handling
+            self._redis = redis.from_url(url, decode_responses=True)
+
+        self._group = group_name
+        self._consumer = consumer_name or f"consumer-{uuid.uuid4()}"
+
+    # ----------------------------
+    # Public API
+    # ----------------------------
+    def publish(self, topic: str, message: BusMessage) -> str:  # noqa: D401
+        """Append one message to a topic. Returns the Bus message id (uuid)."""
+        # Store canonical id and payload JSON in the stream entry
+        fields = {
+            "id": message.id,
+            "payload": json.dumps(message.payload, separators=(",", ":")),
+        }
+        # We ignore the returned entry id here and keep the canonical uuid as the Bus id
+        self._redis.xadd(topic, fields)
+        return message.id
+
+    def read(
+        self,
+        topic: str,
+        last_id: str | None = None,
+        limit: int = 100,
+    ) -> Iterable[BusMessage]:  # noqa: D401
+        """Read messages after last_id (or tail if None)."""
+        if self._group:
+            return list(self._read_with_group(topic, limit))
+        return list(self._read_without_group(topic, last_id, limit))
+
+    # ----------------------------
+    # Internal helpers
+    # ----------------------------
+    def _read_without_group(
+        self, topic: str, last_id: str | None, limit: int
+    ) -> Iterable[BusMessage]:
+        # Tail: last N items in chronological order
+        if last_id is None:
+            entries = self._redis.xrevrange(topic, "+", "-", count=limit) or []
+            entries.reverse()
+            for entry_id, data in entries:
+                yield self._to_bus_message(topic, data, entry_id)
+            return
+
+        # Find last_id by either canonical uuid stored in field 'id' or by entry id
+        cursor = "-"
+        collected: list[tuple[str, dict[str, str]]] = []
+        found = False
+        while True:
+            # Fetch in chunks to avoid pulling the entire stream for very large topics
+            chunk = self._redis.xrange(topic, cursor, "+", count=max(limit * 2, 100)) or []
+            if not chunk:
+                break
+            for entry_id, data in chunk:
+                if not found:
+                    if data.get("id") == last_id or entry_id == last_id:
+                        found = True
+                        continue
+                else:
+                    collected.append((entry_id, data))
+                    if len(collected) >= limit:
+                        break
+            if len(collected) >= limit or chunk[-1][0] == cursor:
+                break
+            cursor = chunk[-1][0]
+
+        for entry_id, data in collected[:limit]:
+            yield self._to_bus_message(topic, data, entry_id)
+
+    def _read_with_group(self, topic: str, limit: int) -> Iterable[BusMessage]:
+        self._ensure_group(topic)
+
+        # Only read messages never delivered to the group ("new"), not pending ones
+        resp = self._redis.xreadgroup(
+            groupname=self._group,
+            consumername=self._consumer,
+            streams={topic: ">"},
+            count=limit,
+            block=0,
+        )
+
+        if not resp:
+            return []
+
+        # resp shape: [(stream, [(entry_id, {field: value, ...}), ...])]
+        _, items = resp[0]
+        messages: list[BusMessage] = []
+        for entry_id, data in items:
+            messages.append(self._to_bus_message(topic, data, entry_id))
+            try:
+                # Acknowledge after conversion so we always deliver at-least-once semantics
+                self._redis.xack(topic, self._group, entry_id)
+            except Exception:
+                # If ack fails, proceed; tests will still detect pending if it occurs
+                pass
+        return messages
+
+    def _ensure_group(self, topic: str) -> None:
+        if not self._group:
+            return
+        try:
+            # Create group at "0" so pre-existing entries are delivered to the group
+            self._redis.xgroup_create(topic, self._group, id="0", mkstream=True)
+        except Exception as exc:
+            # BUSYGROUP: Consumer Group name already exists
+            msg = str(exc)
+            if "BUSYGROUP" in msg or "already exists" in msg:
+                return
+            # Different error, re-raise
+            raise
+
+    @staticmethod
+    def _to_bus_message(topic: str, data: dict[str, str], entry_id: str) -> BusMessage:
+        payload_raw = data.get("payload", "{}")
+        try:
+            payload = json.loads(payload_raw)
+        except Exception:
+            payload = {}
+
+        bus_id = data.get("id") or entry_id
+        return BusMessage(topic=topic, payload=payload, id=bus_id)
+
+
+__all__ = ["RedisBus"]

--- a/magent2/bus/redis_adapter.py
+++ b/magent2/bus/redis_adapter.py
@@ -85,7 +85,8 @@ class RedisBus(Bus):
         found = False
         while True:
             # Fetch in chunks to avoid pulling the entire stream for very large topics
-            chunk = self._redis.xrange(topic, cursor, "+", count=max(limit * 2, 100)) or []
+            start = cursor if cursor == "-" else f"({cursor}"
+            chunk = self._redis.xrange(topic, start, "+", count=max(limit * 2, 100)) or []
             if not chunk:
                 break
             for entry_id, data in chunk:

--- a/tests/test_bus_redis.py
+++ b/tests/test_bus_redis.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import pytest
+
+from magent2.bus.interface import BusMessage
+
+
+def _redis_url() -> str:
+    return os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+
+def _redis_available() -> bool:
+    try:
+        import redis
+
+        r = redis.from_url(_redis_url(), decode_responses=True)
+        try:
+            r.ping()
+            return True
+        except Exception:
+            return False
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_available(), reason="Redis is not available at REDIS_URL"
+)
+
+
+def _unique_topic(prefix: str = "chat:test") -> str:
+    return f"{prefix}:{uuid.uuid4()}"
+
+
+def test_redis_bus_roundtrip() -> None:
+    from magent2.bus.redis_adapter import RedisBus
+
+    topic = _unique_topic()
+    bus = RedisBus(redis_url=_redis_url())
+
+    m1 = BusMessage(topic=topic, payload={"n": 1})
+    m2 = BusMessage(topic=topic, payload={"n": 2})
+
+    id1 = bus.publish(topic, m1)
+    id2 = bus.publish(topic, m2)
+    assert id1 and id2
+
+    out = list(bus.read(topic, last_id=id1))
+    assert len(out) == 1
+    assert out[0].id == id2
+    assert out[0].payload == {"n": 2}
+
+
+def test_redis_bus_tail_read_limit() -> None:
+    from magent2.bus.redis_adapter import RedisBus
+
+    topic = _unique_topic()
+    bus = RedisBus(redis_url=_redis_url())
+
+    ids: list[str] = []
+    for i in range(5):
+        ids.append(bus.publish(topic, BusMessage(topic=topic, payload={"n": i})))
+
+    out = list(bus.read(topic, last_id=None, limit=2))
+    assert [m.payload["n"] for m in out] == [3, 4]
+
+
+def _pending_count_raw(client: Any, topic: str, group: str) -> int:
+    # Try modern redis-py first
+    if hasattr(client, "xpending_range"):
+        try:
+            return len(client.xpending_range(topic, group, "-", "+", 100))
+        except Exception:
+            pass
+    # Fallback to summary shape
+    try:
+        summary = client.xpending(topic, group)
+        # redis-py >= 4 returns dict with "pending"
+        if isinstance(summary, dict) and "pending" in summary:
+            return int(summary["pending"])
+    except Exception:
+        pass
+    # If unsupported, return -1 to indicate unknown
+    return -1
+
+
+def test_redis_bus_consumer_group_ack() -> None:
+    from magent2.bus.redis_adapter import RedisBus
+
+    topic = _unique_topic()
+    group = f"g-{uuid.uuid4()}"
+    bus = RedisBus(redis_url=_redis_url(), group_name=group, consumer_name="c1")
+
+    mid = bus.publish(topic, BusMessage(topic=topic, payload={"n": 1}))
+    assert mid
+
+    out = list(bus.read(topic, last_id=None, limit=10))
+    assert len(out) >= 1
+
+    # Validate messages are acknowledged (no pending) when using consumer groups
+    client = bus._redis
+    pending = _pending_count_raw(client, topic, group)
+    if pending >= 0:
+        assert pending == 0


### PR DESCRIPTION
## Summary

Implements the `RedisBus` adapter, providing a Redis Streams-backed message bus for agents. This enables persistent and scalable message passing, fulfilling the requirements of issue #3.

## Linked Issues

- Closes #3

## Changes

- [ ] Major
- [x] Minor

## Tests

- [x] Unit tests added/updated
- [x] Manual verification steps described
  - Verified locally by starting Redis via `docker compose up -d` (or `redis-server` directly) and running `uv run pytest`. All Redis-specific tests pass.

## Risk & Rollback

- Risk: Low. This is a new component adhering to the existing `Bus` interface, with comprehensive tests. It does not alter frozen contracts or existing core logic.
- Rollback plan: Revert this pull request.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest`
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-2a230e05-8064-4a5a-9aa7-ece448dee13e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a230e05-8064-4a5a-9aa7-ece448dee13e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>