### PR TITLE
Implement safe terminal tool

### DIFF
--- a/magent2/tools/__init__.py
+++ b/magent2/tools/__init__.py
@@ -1,0 +1,3 @@
+"""Tool packages for magent2 (terminal, todo, mcp)."""
+
+__all__ = []

--- a/magent2/tools/terminal/__init__.py
+++ b/magent2/tools/terminal/__init__.py
@@ -1,0 +1,3 @@
+from .tool import TerminalTool
+
+__all__ = ["TerminalTool"]

--- a/magent2/tools/terminal/tool.py
+++ b/magent2/tools/terminal/tool.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import shlex
+import signal
+import time
+from pathlib import Path
+from subprocess import DEVNULL, PIPE, Popen, TimeoutExpired
+from typing import Any
+
+
+def _truncate_to_bytes(text: str, limit_bytes: int) -> tuple[str, bool]:
+    data = text.encode("utf-8", errors="ignore")
+    if len(data) <= limit_bytes:
+        return text, False
+    truncated = data[:limit_bytes]
+    return truncated.decode("utf-8", errors="ignore"), True
+
+
+class TerminalTool:
+    """Safe terminal execution tool with allowlist, timeout, and output caps.
+
+    Parameters
+    ----------
+    allowed_commands:
+        List of command basenames allowed to execute (e.g., "bash", "python3", "echo").
+    timeout_seconds:
+        Maximum wall time for a command before it is forcefully terminated.
+    output_cap_bytes:
+        Maximum number of bytes to retain from combined stdout+stderr output.
+    extra_env:
+        Extra environment variables to inject into the sanitized environment.
+    """
+
+    def __init__(
+        self,
+        *,
+        allowed_commands: list[str] | None = None,
+        timeout_seconds: float = 5.0,
+        output_cap_bytes: int = 8_192,
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.allowed_commands: list[str] = allowed_commands or []
+        self.timeout_seconds: float = timeout_seconds
+        self.output_cap_bytes: int = output_cap_bytes
+        self.extra_env: dict[str, str] = extra_env or {}
+
+    def _sanitize_env(self) -> dict[str, str]:
+        # Minimal, deterministic environment
+        env: dict[str, str] = {}
+        # Provide a safe PATH to find basic utilities
+        env["PATH"] = "/usr/bin:/bin:/usr/local/bin"
+        # Ensure non-interactive behavior
+        env["LC_ALL"] = "C"
+        # Inject explicitly provided safe variables
+        for key, value in self.extra_env.items():
+            env[key] = value
+        return env
+
+    def _assert_allowed(self, command: str) -> None:
+        tokens = shlex.split(command)
+        if not tokens:
+            raise ValueError("Empty command")
+        cmd = os.path.basename(tokens[0])
+        if cmd not in self.allowed_commands:
+            raise PermissionError(f"Command '{cmd}' is not allowed")
+
+    def run(self, command: str, cwd: str | None = None) -> dict[str, Any]:
+        self._assert_allowed(command)
+
+        working_dir: str | None
+        if cwd is None:
+            working_dir = None
+        else:
+            working_dir = str(Path(cwd))
+
+        env = self._sanitize_env()
+
+        # Build argv for Popen without invoking a shell
+        argv = shlex.split(command)
+
+        start = time.monotonic()
+        proc = Popen(
+            argv,
+            stdin=DEVNULL,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=working_dir,
+            env=env,
+            text=True,
+            start_new_session=True,
+        )
+        timeout = False
+        try:
+            stdout, stderr = proc.communicate(timeout=self.timeout_seconds)
+        except TimeoutExpired:
+            timeout = True
+            try:
+                # Terminate whole process group
+                os.killpg(proc.pid, signal.SIGKILL)
+            except Exception:
+                proc.kill()
+            stdout, stderr = proc.communicate()
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        combined = stdout or ""
+        if stderr:
+            if combined and not combined.endswith("\n"):
+                combined += "\n"
+            combined += stderr
+
+        out_text, was_truncated = _truncate_to_bytes(combined, self.output_cap_bytes)
+
+        result: dict[str, Any] = {
+            "ok": (proc.returncode == 0) and not timeout,
+            "exit_code": proc.returncode,
+            "timeout": timeout,
+            "stdout": out_text,
+            "truncated": was_truncated,
+            "duration_ms": duration_ms,
+        }
+        return result
+
+
+__all__ = ["TerminalTool"]

--- a/tests/test_terminal_tool.py
+++ b/tests/test_terminal_tool.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from magent2.tools.terminal.tool import TerminalTool
+
+
+@pytest.fixture()
+def tmp_script_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "scripts"
+    d.mkdir()
+    return d
+
+
+def write_script(dirpath: Path, name: str, content: str) -> Path:
+    path = dirpath / name
+    path.write_text(content)
+    path.chmod(0o755)
+    return path
+
+
+def test_allowlist_blocks_unapproved_command(tmp_script_dir: Path) -> None:
+    tool = TerminalTool(allowed_commands=["echo", "bash", "python3"])  # whitelist
+    # a clearly unsafe command name not in allowlist
+    cmd = "rm -rf /"
+    with pytest.raises(Exception):
+        tool.run(cmd)
+
+
+def test_allowlist_allows_whitelisted_command(tmp_script_dir: Path) -> None:
+    tool = TerminalTool(allowed_commands=["echo", "bash", "python3"])
+    result = tool.run("echo hello")
+    assert result["ok"] is True
+    assert "hello" in result["stdout"]
+
+
+def test_timeout_kills_long_running_process(tmp_script_dir: Path) -> None:
+    tool = TerminalTool(allowed_commands=["bash", "sleep"], timeout_seconds=0.5)
+    # sleep longer than timeout
+    result = tool.run("bash -lc 'sleep 5'")
+    assert result["ok"] is False
+    assert result["timeout"] is True
+
+
+def test_output_cap_truncates_large_output(tmp_script_dir: Path) -> None:
+    tool = TerminalTool(allowed_commands=["python3"], output_cap_bytes=100)
+    # generate 1000 bytes via python
+    result = tool.run("python3 -c \"print('x'*1000)\"")
+    assert result["ok"] is True
+    assert result["truncated"] is True
+    assert len(result["stdout"].encode()) <= 100
+
+
+def test_non_interactive_prevents_stdin_block(tmp_script_dir: Path) -> None:
+    tool = TerminalTool(allowed_commands=["bash"], timeout_seconds=1.0)
+    # command that would wait for input; we ensure no stdin is attached and it times out or exits
+    result = tool.run("bash -lc 'read -t 0.1 var || echo noinput'")
+    assert result["ok"] is True
+    assert "noinput" in result["stdout"]
+
+
+def test_sanitized_env(tmp_script_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRET_TOKEN", "supersecret")
+    tool = TerminalTool(allowed_commands=["bash"], extra_env={"SAFE_FLAG": "1"})
+    result = tool.run("bash -lc 'env | sort'", cwd=str(tmp_script_dir))
+    # environment should not include SECRET_TOKEN
+    assert "SECRET_TOKEN=" not in result["stdout"]
+    # but should include SAFE_FLAG
+    assert "SAFE_FLAG=1" in result["stdout"]


### PR DESCRIPTION
## Summary

Implements the Terminal Tool (#5) for safe command execution within agents. It features an allowlist for commands, enforces timeouts, caps output size, and runs commands in a sanitized environment to prevent privilege escalation or unintended side effects.

## Linked Issues

- Closes #5

## Changes

- [ ] Major
- [x] Minor

## Tests

- [x] Unit tests added/updated
- [x] Manual verification steps described
  - `uv run pytest -q` passes
  - `uv run ruff check` and `uv run ruff format` are clean
  - `uv run pre-commit run` passes on staged files

## Risk & Rollback

- Risk: Low. This is a new, isolated tool with built-in safety mechanisms. It does not modify existing core contracts or introduce new infrastructure.
- Rollback plan: Revert the PR. The changes are self-contained within `magent2/tools/terminal/` and `tests/test_terminal_tool.py`.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest`
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-8bec1062-022a-465c-8f12-cd715bfbeded">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bec1062-022a-465c-8f12-cd715bfbeded">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>