### PR TITLE
Implement redis todo tool

### DIFF
--- a/magent2/tools/todo/__init__.py
+++ b/magent2/tools/todo/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+__all__ = [
+    "models",
+]

--- a/magent2/tools/todo/models.py
+++ b/magent2/tools/todo/models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Task(BaseModel):
+    """A simple Todo task persisted in the store.
+
+    - Sorted by created_at for listing within a conversation
+    - Metadata is an unstructured dict for extensibility
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    conversation_id: str
+    title: str
+    completed: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: _dt.datetime = Field(default_factory=lambda: _dt.datetime.now(_dt.UTC))
+
+
+__all__ = ["Task"]

--- a/magent2/tools/todo/redis_store.py
+++ b/magent2/tools/todo/redis_store.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+
+import redis
+
+from .models import Task
+
+
+class TodoStore:
+    """Pluggable Todo store interface.
+
+    Concrete implementations should provide CRUD operations and listing by
+    conversation ordered by creation time.
+    """
+
+    def create_task(
+        self, *, conversation_id: str, title: str, metadata: dict | None = None
+    ) -> Task:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def get_task(self, task_id: str) -> Task | None:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def list_tasks(self, conversation_id: str) -> list[Task]:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def update_task(
+        self,
+        task_id: str,
+        *,
+        title: str | None = None,
+        completed: bool | None = None,
+        metadata: dict | None = None,
+    ) -> Task | None:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def delete_task(self, task_id: str) -> bool:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+
+class RedisTodoStore(TodoStore):
+    """Redis-backed Todo store.
+
+    Data structures:
+    - Hash per task: key `{prefix}:task:{id}` with fields `json`
+    - Sorted set per conversation for ordering by `created_at` timestamp:
+      key `{prefix}:conv:{conversation_id}` with score=created_at epoch seconds, member=task_id
+    """
+
+    def __init__(self, *, url: str, key_prefix: str = "todo") -> None:
+        self._redis = redis.Redis.from_url(url)
+        self._prefix = key_prefix.rstrip(":")
+
+    # key helpers
+    def _task_key(self, task_id: str) -> str:
+        return f"{self._prefix}:task:{task_id}"
+
+    def _conv_key(self, conversation_id: str) -> str:
+        return f"{self._prefix}:conv:{conversation_id}"
+
+    def create_task(
+        self, *, conversation_id: str, title: str, metadata: dict | None = None
+    ) -> Task:
+        task = Task(conversation_id=conversation_id, title=title, metadata=metadata or {})
+        data = task.model_dump()
+        payload = json.dumps(data, separators=(",", ":"))
+        p = self._redis.pipeline()
+        p.hset(self._task_key(task.id), mapping={"json": payload})
+        p.zadd(self._conv_key(conversation_id), {task.id: task.created_at.timestamp()})
+        p.execute()
+        return task
+
+    def get_task(self, task_id: str) -> Task | None:
+        raw = self._redis.hget(self._task_key(task_id), "json")
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+            return Task.model_validate(data)
+        except Exception:
+            return None
+
+    def list_tasks(self, conversation_id: str) -> list[Task]:
+        ids = self._redis.zrange(self._conv_key(conversation_id), 0, -1)
+        if not ids:
+            return []
+        task_ids = [i.decode("utf-8") if isinstance(i, bytes) else i for i in ids]
+        result: list[Task] = []
+        for tid in task_ids:
+            t = self.get_task(tid)
+            if t is not None:
+                result.append(t)
+        return result
+
+    def update_task(
+        self,
+        task_id: str,
+        *,
+        title: str | None = None,
+        completed: bool | None = None,
+        metadata: dict | None = None,
+    ) -> Task | None:
+        current = self.get_task(task_id)
+        if current is None:
+            return None
+        if title is not None:
+            current.title = title
+        if completed is not None:
+            current.completed = completed
+        if metadata is not None:
+            current.metadata = metadata
+        payload = json.dumps(current.model_dump(), separators=(",", ":"))
+        self._redis.hset(self._task_key(task_id), mapping={"json": payload})
+        return current
+
+    def delete_task(self, task_id: str) -> bool:
+        task = self.get_task(task_id)
+        if task is None:
+            return False
+        p = self._redis.pipeline()
+        p.delete(self._task_key(task_id))
+        p.zrem(self._conv_key(task.conversation_id), task_id)
+        res = p.execute()
+        # Return True if either deletion removed something
+        return bool(sum(int(x) for x in res))
+
+
+__all__ = ["TodoStore", "RedisTodoStore"]

--- a/tests/test_todo_store.py
+++ b/tests/test_todo_store.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+
+import pytest
+import redis
+
+from magent2.tools.todo.redis_store import RedisTodoStore
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+
+def _redis_available(url: str) -> bool:
+    try:
+        client = redis.Redis.from_url(url)
+        return bool(client.ping())
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_available(REDIS_URL),
+    reason=("Redis not available. Start it with `docker compose up -d` or set REDIS_URL."),
+)
+
+
+@pytest.fixture()
+def key_prefix() -> str:
+    return f"testtodo:{uuid.uuid4()}"
+
+
+@pytest.fixture()
+def store(key_prefix: str) -> Generator[RedisTodoStore, None, None]:
+    # Import here to keep tests importable before implementation lands
+    from magent2.tools.todo.redis_store import RedisTodoStore
+
+    s = RedisTodoStore(url=REDIS_URL, key_prefix=key_prefix)
+    yield s
+
+
+def test_create_and_get_persists_across_instances(store: RedisTodoStore, key_prefix: str) -> None:
+    from magent2.tools.todo.redis_store import RedisTodoStore
+
+    t = store.create_task(conversation_id="conv_a", title="Write tests")
+
+    assert t.id
+    fetched = store.get_task(t.id)
+    assert fetched is not None
+    assert fetched.title == "Write tests"
+    assert fetched.conversation_id == "conv_a"
+    assert fetched.completed is False
+
+    # Recreate store to simulate process restart
+    store2 = RedisTodoStore(url=REDIS_URL, key_prefix=key_prefix)
+    fetched2 = store2.get_task(t.id)
+    assert fetched2 is not None
+    assert fetched2.id == t.id
+
+
+def test_list_ordering_by_created_at(store: RedisTodoStore) -> None:
+    # Create spaced tasks to ensure ordering by created_at
+    t1 = store.create_task(conversation_id="conv_b", title="First")
+    time.sleep(0.01)
+    t2 = store.create_task(conversation_id="conv_b", title="Second")
+    time.sleep(0.01)
+    t3 = store.create_task(conversation_id="conv_b", title="Third")
+
+    tasks = store.list_tasks("conv_b")
+    assert [x.id for x in tasks] == [t1.id, t2.id, t3.id]
+
+
+def test_update_and_complete(store: RedisTodoStore) -> None:
+    t = store.create_task(conversation_id="conv_c", title="Edit me")
+
+    updated = store.update_task(t.id, title="Edited", completed=True)
+    assert updated is not None
+    assert updated.title == "Edited"
+    assert updated.completed is True
+
+    fetched = store.get_task(t.id)
+    assert fetched is not None
+    assert fetched.title == "Edited"
+    assert fetched.completed is True
+
+
+def test_delete_task(store: RedisTodoStore) -> None:
+    t = store.create_task(conversation_id="conv_d", title="Remove me")
+    ok = store.delete_task(t.id)
+    assert ok is True
+    assert store.get_task(t.id) is None
+    assert all(x.id != t.id for x in store.list_tasks("conv_d"))
+
+
+def test_metadata_persists(store: RedisTodoStore) -> None:
+    t = store.create_task(
+        conversation_id="conv_e",
+        title="With meta",
+        metadata={"priority": "high", "tags": ["a", "b"]},
+    )
+    got = store.get_task(t.id)
+    assert got is not None
+    assert got.metadata["priority"] == "high"
+    assert got.metadata["tags"] == ["a", "b"]


### PR DESCRIPTION
## Summary

Implements the Todo Tool, providing a `Task` model and a Redis-backed store for CRUD operations and ordered listing of tasks within a conversation. This addresses the requirements for issue #6.

## Linked Issues

- Closes #6

## Changes

- [ ] Major
- [x] Minor

## Tests

- [x] Unit tests added/updated
- [x] Manual verification steps described
    *   Ensure Redis is running: `docker compose up -d`
    *   Run tests: `uv run pytest -q` (Redis-dependent tests will skip if Redis is unavailable)

## Risk & Rollback

- Risk: Low. This is a new, isolated component and does not modify existing core functionality or frozen contracts.
- Rollback plan: Revert this PR.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest`
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-a0194749-67ff-40d0-8687-3e74098608f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0194749-67ff-40d0-8687-3e74098608f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>