### PR TITLE
Implement observability features

### DIFF
--- a/magent2/observability/__init__.py
+++ b/magent2/observability/__init__.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import sys
+import time
+import uuid
+from collections.abc import Generator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+SENSITIVE_KEYS = {"openai_api_key", "api_key", "token", "authorization", "password", "secret"}
+
+
+def _iso_now() -> str:
+    return dt.datetime.now(dt.UTC).isoformat()
+
+
+def _redact_value(value: Any) -> Any:
+    return "[REDACTED]"
+
+
+def _redact(obj: Any) -> Any:
+    if isinstance(obj, Mapping):
+        redacted: dict[str, Any] = {}
+        for k, v in obj.items():
+            if isinstance(k, str) and k.lower() in SENSITIVE_KEYS:
+                redacted[k] = _redact_value(v)
+            else:
+                redacted[k] = _redact(v)
+        return redacted
+    if isinstance(obj, list | tuple):
+        return [_redact(v) for v in obj]
+    return obj
+
+
+class JsonLogFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        payload: dict[str, Any] = {
+            "ts": _iso_now(),
+            "level": record.levelname.lower(),
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Include extra fields if present
+        for attr in ("metadata", "event", "span_id", "parent_id", "duration_ms"):
+            if hasattr(record, attr):
+                payload[attr] = getattr(record, attr)
+
+        # Map custom span_name to public 'name' field in JSON
+        span_name = getattr(record, "span_name", None)
+        if span_name is not None:
+            payload["name"] = span_name
+
+        if "metadata" in payload and isinstance(payload["metadata"], dict):
+            payload["metadata"] = _redact(payload["metadata"])
+
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def get_json_logger(name: str = "magent2") -> logging.Logger:
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler(stream=sys.stdout)
+        handler.setFormatter(JsonLogFormatter())
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+    return logger
+
+
+@dataclass
+class Span:
+    span_id: str
+    name: str
+    start_ns: int
+    parent_id: str | None
+
+
+class Tracer:
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or get_json_logger("magent2.trace")
+        self._stack: list[Span] = []
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Generator[Span, None, None]:
+        span_id = str(uuid.uuid4())
+        parent_id = self._stack[-1].span_id if self._stack else None
+        span = Span(
+            span_id=span_id,
+            name=name,
+            start_ns=time.perf_counter_ns(),
+            parent_id=parent_id,
+        )
+
+        self._logger.info(
+            "span start",
+            extra={
+                "event": "span_start",
+                "span_name": name,
+                "span_id": span_id,
+                "parent_id": parent_id,
+                "metadata": dict(metadata or {}),
+            },
+        )
+        self._stack.append(span)
+        try:
+            yield span
+        finally:
+            end_ns = time.perf_counter_ns()
+            duration_ms = (end_ns - span.start_ns) / 1_000_000.0
+            self._logger.info(
+                "span end",
+                extra={
+                    "event": "span_end",
+                    "span_name": name,
+                    "span_id": span_id,
+                    "parent_id": parent_id,
+                    "duration_ms": duration_ms,
+                },
+            )
+            # Pop if it is the current top
+            if self._stack and self._stack[-1].span_id == span_id:
+                self._stack.pop()
+
+
+class Metrics:
+    def __init__(self) -> None:
+        self._counters: dict[tuple[str, tuple[tuple[str, str], ...]], int] = {}
+
+    def increment(
+        self,
+        name: str,
+        labels: Mapping[str, str] | None = None,
+        amount: int = 1,
+    ) -> None:
+        label_items: tuple[tuple[str, str], ...] = tuple(sorted((labels or {}).items()))
+        key = (name, label_items)
+        self._counters[key] = self._counters.get(key, 0) + amount
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for (name, label_items), value in sorted(self._counters.items()):
+            out.append(
+                {
+                    "name": name,
+                    "labels": dict(label_items),
+                    "value": value,
+                }
+            )
+        return out

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from magent2.observability import Metrics, Tracer, get_json_logger
+
+
+def _parse_json_lines(output: str) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in output.strip().splitlines() if line.strip()]
+
+
+def test_json_logger_redacts_and_formats(capsys: Any) -> None:
+    logger = get_json_logger("obs-test")
+    logger.setLevel(20)  # INFO
+    logger.info(
+        "hello",
+        extra={
+            "metadata": {
+                "OPENAI_API_KEY": "sk-abc",
+                "token": "XYZ",
+                "safe": "ok",
+            }
+        },
+    )
+
+    out = capsys.readouterr().out
+    lines = _parse_json_lines(out)
+    assert len(lines) == 1
+    rec = lines[0]
+    assert rec["message"] == "hello"
+    assert rec["level"] == "info"
+    assert rec["logger"] == "obs-test"
+    md = rec.get("metadata")
+    assert isinstance(md, dict)
+    assert md["safe"] == "ok"
+    assert md["OPENAI_API_KEY"] == "[REDACTED]"
+    assert md["token"] == "[REDACTED]"
+
+
+def test_tracer_spans_and_parent_child(capsys: Any) -> None:
+    logger = get_json_logger("obs-test-trace")
+    tracer = Tracer(logger)
+
+    with tracer.span("parent", {"conversation_id": "c1"}) as _parent_span:
+        with tracer.span("child", {"tool": "terminal.run"}):
+            pass
+
+    out = capsys.readouterr().out
+    lines = _parse_json_lines(out)
+    starts = [d for d in lines if d.get("event") == "span_start"]
+    ends = [d for d in lines if d.get("event") == "span_end"]
+
+    assert len(starts) == 2
+    assert len(ends) == 2
+
+    parent_start = next(d for d in starts if d.get("name") == "parent")
+    child_start = next(d for d in starts if d.get("name") == "child")
+
+    assert "span_id" in parent_start and parent_start["span_id"]
+    assert "span_id" in child_start and child_start["span_id"]
+    assert child_start.get("parent_id") == parent_start.get("span_id")
+
+    parent_end = next(d for d in ends if d.get("span_id") == parent_start["span_id"])
+    assert parent_end["name"] == "parent"
+    assert isinstance(parent_end.get("duration_ms"), int | float)
+
+
+def test_metrics_counters_increment_and_snapshot() -> None:
+    metrics = Metrics()
+    metrics.increment("tool_calls", {"tool": "terminal"}, 2)
+    metrics.increment("tool_calls", {"tool": "terminal"})
+
+    snap = metrics.snapshot()
+    entry = next(
+        e for e in snap if e["name"] == "tool_calls" and e["labels"].get("tool") == "terminal"
+    )
+    assert entry["value"] == 3


### PR DESCRIPTION
## Summary

Implements core observability features for `magent2`. This includes a structured JSON logger with sensitive data redaction, a `Tracer` context manager for creating hierarchical spans with duration, and an in-memory `Metrics` class for labeled counters.

## Linked Issues

- Closes #9

## Changes

- [ ] Major
- [x] Minor

## Tests

- [x] Unit tests added/updated
- [ ] Manual verification steps described (Unit tests cover acceptance criteria)

## Risk & Rollback

- Risk: Low. This is a new, isolated module with no external dependencies beyond the standard library. It introduces no breaking changes to existing components or contracts.
- Rollback plan: Revert this PR.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest`
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-a9247257-0402-43f5-b182-2fb30628cd80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9247257-0402-43f5-b182-2fb30628cd80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>