### PR TITLE
Execute handover document 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,13 @@ Environment variables:
 
 - `REDIS_URL` (default `redis://localhost:6379/0` or compose service URL)
 - `AGENT_NAME` (worker target agent; default `DevAgent`)
-- `OPENAI_API_KEY` (required if using real Agents SDK models/tools)
+- `AGENT_MODEL` (Agents SDK model name, e.g., `gpt-4o-mini`; default `gpt-4o-mini`)
+- `AGENT_INSTRUCTIONS` (inline agent instructions; optional)
+- `AGENT_INSTRUCTIONS_FILE` (path to a file with agent instructions; overrides `AGENT_INSTRUCTIONS`)
+- `AGENT_TOOLS` (comma-separated tool names; currently unused/no-op, reserved for follow-ups)
+- `OPENAI_API_KEY` (if set, the Worker uses the OpenAI Agents SDK runner; if unset, it falls back to EchoRunner for local/dev)
+
+At startup, the Worker selects the runner based on `OPENAI_API_KEY` and logs the choice (Echo vs OpenAI) with the agent name/model.
 
 ## Contracts
 

--- a/docs/HANDOVERS/feat-mcp-stdio-servers-#36.md
+++ b/docs/HANDOVERS/feat-mcp-stdio-servers-#36.md
@@ -33,6 +33,7 @@ Introduce a configuration loader that resolves MCP servers for a given agent fro
 - `AGENT_<AgentName>_MCP_<N>_BLOCK` (comma-separated blocklist of tool names)
 
 Policy:
+
 - Default-deny unless allowlist is present (recommended). If both allow and block set, exposure = allow − block.
 - Only pass the explicit `env` provided; do not inherit parent environment by default.
 
@@ -86,6 +87,7 @@ Implementation: `magent2/tools/mcp/registry.py`
 ### 4) Exports
 
 Update `magent2/tools/mcp/__init__.py` to export:
+
 - `MCPServerConfig`, `load_agent_mcp_configs`
 - `ToolInfo`, `MCPToolGateway`
 - `load_for_agent`
@@ -101,19 +103,23 @@ Update `magent2/tools/mcp/__init__.py` to export:
 Augment `tests/test_mcp_stdio.py` with gateway tests:
 
 1) `test_gateway_lists_and_calls_filtered_tools`
+
 - Temp server advertises `echo` and `secret` tools.
 - Allowlist only `echo`; assert `list_tools()` exposes only `echo` and `call('echo', {text:'hi'})` returns `hi`.
 
 2) `test_gateway_cleanup_idempotent`
+
 - Create gateway, start, `close()`, `close()` again; no exception.
 
 Optional demo server test (graceful skip):
 
 Create `tests/test_mcp_demo_optional.py`:
+
 - Probe availability (e.g., check `shutil.which("npx")`, then attempt to spawn `npx -y @modelcontextprotocol/server-memory --stdio`); on failure/timeout → `pytest.skip("demo MCP server unavailable")`.
 - If available: `initialize`, `tools/list` smoke, then `close`.
 
 Probe example:
+
 ```python
 import shutil, subprocess, pytest
 
@@ -136,6 +142,7 @@ Agent `DevAgent`:
 - `AGENT_DevAgent_MCP_0_ALLOW=echo,search`  (adjust to real tool names)
 
 Filesystem variant:
+
 - `AGENT_DevAgent_MCP_1_CMD=npx`
 - `AGENT_DevAgent_MCP_1_ARGS=-y,@modelcontextprotocol/server-filesystem,--stdio,/path/to/dir`
 - `AGENT_DevAgent_MCP_1_ALLOW=list,read`

--- a/docs/HANDOVERS/feat-terminal-function-tools-#34.md
+++ b/docs/HANDOVERS/feat-terminal-function-tools-#34.md
@@ -149,6 +149,7 @@ def terminal_run(command: str, cwd: str | None = None) -> str:
 ```
 
 Notes:
+
 - The example above shows a plain function; to expose as an Agents SDK function tool, decorate or wrap per the SDK API. Keep the underlying logic separate so tests can target `terminal_run` directly without requiring the SDK import.
 
 ### SDK offline quick reference (OpenAI Agents SDK 0.2.11)
@@ -209,6 +210,7 @@ agent = Agent(
 ```
 
 Notes:
+
 - The decorator inspects function signature and docstring to build the tool schema automatically.
 - Tool functions should return compact outputs (e.g., short strings) to keep model context efficient.
 - Use our wrapper’s policy controls via environment variables listed above.
@@ -223,6 +225,7 @@ Notes:
   - Optional: if SDK decorator is confirmed and lightweight, assert a function-tool schema is generated with the expected parameters (skip if SDK unavailable).
 
 Testing notes:
+
 - Reuse `tmp_path` and pattern from `tests/test_terminal_tool.py` where helpful.
 - Use `monkeypatch.setenv` to configure env per test to avoid cross-test contamination.
 

--- a/docs/HANDOVERS/feat-todo-function-tools-#35.md
+++ b/docs/HANDOVERS/feat-todo-function-tools-#35.md
@@ -1,18 +1,21 @@
 ### Handover: Expose Todo tool as Agents SDK function tools (Issue #35)
 
 #### Context
+
 - Goal: Expose CRUD + list operations as OpenAI Agents SDK function tools backed by `RedisTodoStore`.
 - Scope limited to `magent2/tools/todo/` and tests under `tests/`.
 - Do not change frozen v1 contracts (envelope, bus). See `docs/CONTRACTS.md`.
 - Reuse Redis fixtures from `tests/conftest.py` and the store tests in `tests/test_todo_store.py`.
 
 #### Requirements
+
 - Define Agents SDK function tools for: create, get, list, update, delete.
 - Validate inputs; use `Task` model for (de)serialization; ensure JSON-safe outputs.
 - Read `REDIS_URL` from environment; handle transient Redis errors gracefully.
 - Pass `just check` locally: ruff, mypy, complexity, secrets, pytest.
 
 #### References (offline)
+
 - OpenAI Agents SDK quick links and cheats: `docs/refs/openai-agents-sdk.md` (contains import paths and examples usable offline).
 - Redis Streams bus notes: `docs/refs/redis-streams.md`.
 - Store + model: `magent2/tools/todo/redis_store.py`, `magent2/tools/todo/models.py`.
@@ -22,11 +25,13 @@
 ### Design
 
 #### File layout
+
 - Add `magent2/tools/todo/tools.py` exporting five function tools and helpers.
   - Public exports: `create_task_tool`, `get_task_tool`, `list_tasks_tool`, `update_task_tool`, `delete_task_tool`.
   - Internal helpers: `_get_store()`, `_serialize_task(task: Task) -> dict`, simple validators.
 
 #### Tool APIs (inputs/outputs)
+
 - Common: return dicts with explicit keys; never return Pydantic models directly.
 
 - Create
@@ -50,19 +55,23 @@
   - Output: `{ "ok": bool }`.
 
 Notes:
+
 - Task serialization: `Task.model_dump(mode="json")` to ensure RFC3339 `created_at` and JSON-safe types.
 - Inputs validated for non-empty strings and basic types before store calls. More detailed schema comes from Python type hints → Agents SDK infers JSON schema.
 
 #### Environment/config
+
 - `REDIS_URL`: read from env, fallback `redis://localhost:6379/0` (matches README/compose defaults).
 - `TODO_STORE_PREFIX`: optional env to override Redis key prefix (default `todo`) to support test isolation.
 
 #### Store access
+
 - `_get_store()`:
   - Reads `REDIS_URL` and `TODO_STORE_PREFIX` envs.
   - Returns `RedisTodoStore(url=..., key_prefix=...)`.
 
 #### Error handling
+
 - Catch `redis.exceptions.RedisError` around store calls.
   - For delete: return `{ "ok": false, "error": "<message>", "transient": true }`.
   - For get/update: `{ "task": null, "error": "...", "transient": true }`.
@@ -71,6 +80,7 @@ Notes:
 - Input validation errors raise `ValueError` with concise messages (Agents SDK will surface them as tool errors).
 
 #### Function tool decorator (Agents SDK)
+
 - Import and decorate using the offline cheatsheet in `docs/refs/openai-agents-sdk.md`:
   - `from agents import function_tool`
   - Decorate functions with `@function_tool(name="...", description="...")` (name/description optional; name defaults to function name).
@@ -79,6 +89,7 @@ Notes:
 ---
 
 ### Implementation plan
+
 1) Create `magent2/tools/todo/tools.py` with:
    - `_serialize_task(task: Task) -> dict[str, Any]` using `model_dump(mode="json")`.
    - `_get_store()` reading env and returning `RedisTodoStore`.
@@ -131,15 +142,18 @@ def create_task_tool(conversation_id: str, title: str, metadata: dict[str, Any] 
 ---
 
 ### Risks & mitigations
+
 - SDK import name/version drift → use `from agents import function_tool` (pinned via `pyproject.toml`), documented in refs.
 - Redis connectivity/transient errors → catch and mark `transient: true`; allow caller retry.
 - Test isolation → per-test `TODO_STORE_PREFIX` prevents collisions.
 
 ### Acceptance
+
 - Tools implemented and exported; tests cover CRUD/list; `just check` passes.
 - No changes to frozen contracts.
 
 ### Next steps for implementer
+
 1) Implement `magent2/tools/todo/tools.py` per design.
 2) Add `tests/test_todo_tools.py` with fixtures/cases above.
 3) Run `just check`; fix issues; open PR referencing #35.

--- a/docs/refs/openai-agents-sdk.md
+++ b/docs/refs/openai-agents-sdk.md
@@ -165,10 +165,12 @@ asyncio.run(main())
 
 - Pass a session object to preserve history across runs: `Runner.run_streamed(agent, input=..., session=session)`.
 - If available in your installed version, a persistent session can be imported as:
+
   ```python
   from agents.extensions.memory.sqlalchemy_session import SQLAlchemySession  # if present
   session = SQLAlchemySession("sqlite:///./agents.db", key="conv_123")
   ```
+
 - If unavailable, keep an in-memory dict keyed by `conversation_id` and reuse the same object (or `None`) consistently.
 
 ### Tools (optional)

--- a/magent2/runner/config.py
+++ b/magent2/runner/config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class RunnerConfig:
+    api_key: str | None
+    agent_name: str
+    model: str
+    instructions: str
+    tools: list[str]
+
+
+def _read_instructions() -> str:
+    path = os.getenv("AGENT_INSTRUCTIONS_FILE")
+    if path:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read()
+        except Exception:
+            # Fallback to env if file missing/unreadable
+            pass
+    return os.getenv("AGENT_INSTRUCTIONS", "You are a helpful assistant.")
+
+
+def _read_tools() -> list[str]:
+    raw = os.getenv("AGENT_TOOLS", "").strip()
+    if not raw:
+        return []
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def load_config(env: dict[str, str] | None = None) -> RunnerConfig:
+    e: dict[str, Any] = dict(os.environ)
+    if env:
+        e.update(env)
+    return RunnerConfig(
+        api_key=e.get("OPENAI_API_KEY"),
+        agent_name=e.get("AGENT_NAME", "DevAgent"),
+        model=e.get("AGENT_MODEL", "gpt-4o-mini"),
+        instructions=_read_instructions(),
+        tools=_read_tools(),
+    )
+
+
+__all__ = ["RunnerConfig", "load_config"]
+

--- a/magent2/runner/config.py
+++ b/magent2/runner/config.py
@@ -18,7 +18,7 @@ def _read_instructions() -> str:
     path = os.getenv("AGENT_INSTRUCTIONS_FILE")
     if path:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 return f.read()
         except Exception:
             # Fallback to env if file missing/unreadable
@@ -47,4 +47,3 @@ def load_config(env: dict[str, str] | None = None) -> RunnerConfig:
 
 
 __all__ = ["RunnerConfig", "load_config"]
-

--- a/magent2/runner/openai_agents_runner.py
+++ b/magent2/runner/openai_agents_runner.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections import deque
+from collections.abc import Iterable
+from queue import Queue
+from typing import Any
+
+from agents import Agent
+from agents import Runner as SDKRunner
+from openai.types.responses import ResponseTextDeltaEvent
+
+from magent2.models.envelope import (
+    BaseStreamEvent,
+    MessageEnvelope,
+    OutputEvent,
+    TokenEvent,
+    ToolStepEvent,
+)
+
+
+class OpenAIAgentsRunner:
+    """Adapter that bridges the async OpenAI Agents SDK stream to our sync Worker protocol.
+
+    - Maintains simple LRU of sessions keyed by conversation_id
+    - Maps SDK events to v1 stream events (TokenEvent, ToolStepEvent, OutputEvent)
+    - Returns a synchronous iterator suitable for the existing Worker loop
+    """
+
+    def __init__(self, agent: Agent, *, session_limit: int = 256) -> None:
+        self._agent = agent
+        self._sessions: dict[str, Any] = {}
+        self._session_order: deque[str] = deque()
+        self._session_limit = max(1, session_limit)
+
+    # ----------------------------
+    # Public API (Runner protocol)
+    # ----------------------------
+    def stream_run(self, envelope: MessageEnvelope) -> Iterable[BaseStreamEvent | dict[str, Any]]:
+        events_queue: Queue[BaseStreamEvent | dict[str, Any] | None] = Queue()
+        sentinel: None = None
+
+        def _runner() -> None:
+            asyncio.run(self._run_streaming(envelope, events_queue))
+            # Signal completion
+            events_queue.put(sentinel)
+
+        thread = threading.Thread(target=_runner, daemon=True)
+        thread.start()
+
+        # Drain the queue until sentinel is received
+        while True:
+            item = events_queue.get()
+            if item is sentinel:
+                break
+            # mypy: item cannot be None here, guarded by sentinel check
+            assert item is not None
+            yield item
+
+    # ----------------------------
+    # Internal helpers
+    # ----------------------------
+    def _get_session(self, conversation_id: str) -> Any:
+        # Simple LRU: move to end on access, evict from left when over limit
+        if conversation_id in self._sessions:
+            try:
+                self._session_order.remove(conversation_id)
+            except ValueError:
+                pass
+            self._session_order.append(conversation_id)
+            return self._sessions[conversation_id]
+
+        # Create a new opaque session object; if SDK exposes a concrete Session,
+        # callers/tests can still verify reuse by identity.
+        session: Any = object()
+        self._sessions[conversation_id] = session
+        self._session_order.append(conversation_id)
+        if len(self._sessions) > self._session_limit:
+            evict_id = self._session_order.popleft()
+            try:
+                del self._sessions[evict_id]
+            except KeyError:
+                pass
+        return session
+
+    async def _run_streaming(
+        self,
+        envelope: MessageEnvelope,
+        queue: Queue[BaseStreamEvent | dict[str, Any] | None],
+    ) -> None:
+        session = self._get_session(envelope.conversation_id)
+        # Kick off the SDK streamed run
+        result_stream = SDKRunner.run_streamed(
+            self._agent,
+            input=envelope.content or "",
+            session=session,
+        )
+
+        token_index = 0
+        accumulated_text_parts: list[str] = []
+
+        saw_explicit_output = False
+        async for ev in result_stream.stream_events():
+            mapped = self._map_event(envelope.conversation_id, ev, token_index)
+            if mapped is None:
+                continue
+            if isinstance(mapped, TokenEvent):
+                token_index += 1
+                accumulated_text_parts.append(mapped.text)
+                queue.put(mapped)
+            elif isinstance(mapped, ToolStepEvent):
+                queue.put(mapped)
+            elif isinstance(mapped, OutputEvent):
+                # If the SDK yields a final output explicitly, prefer it
+                queue.put(mapped)
+                saw_explicit_output = True
+
+        # Ensure we always emit a final OutputEvent if not already provided
+        if not saw_explicit_output:
+            final_text = "".join(accumulated_text_parts)
+            queue.put(
+                OutputEvent(
+                    conversation_id=envelope.conversation_id,
+                    text=final_text,
+                )
+            )
+
+    def _map_event(
+        self, conversation_id: str, ev: Any, token_index: int
+    ) -> BaseStreamEvent | None:
+        """Map SDK stream event to our v1 stream events.
+
+        Tolerant to either typed objects or dict-shaped events.
+        """
+        ev_type = getattr(ev, "type", None) or (ev.get("type") if isinstance(ev, dict) else None)
+        data = getattr(ev, "data", None) if not isinstance(ev, dict) else ev.get("data")
+
+        # 1) raw model token deltas
+        if ev_type == "raw_response_event":
+            # data can be a typed ResponseTextDeltaEvent or a dict-like with key 'delta'
+            if isinstance(data, ResponseTextDeltaEvent):
+                delta = getattr(data, "delta", None)
+                if isinstance(delta, str) and delta:
+                    return TokenEvent(conversation_id=conversation_id, text=delta, index=token_index)
+                return None
+            if isinstance(data, dict):
+                delta_val = data.get("delta")
+                if isinstance(delta_val, str) and delta_val:
+                    return TokenEvent(conversation_id=conversation_id, text=delta_val, index=token_index)
+            return None
+
+        # 2) run item events: tools, messages, etc.
+        if ev_type == "run_item_stream_event":
+            item = data
+            # Heuristics for tool invocation
+            if item is not None:
+                # Prefer attribute access, fallback to dict keys
+                name = getattr(item, "name", None)
+                if name is None and isinstance(item, dict):
+                    name = item.get("name") or item.get("tool_name")
+
+                args = getattr(item, "arguments", None)
+                if args is None and isinstance(item, dict):
+                    args = item.get("arguments") or item.get("args")
+
+                result = getattr(item, "result", None)
+                if result is None and isinstance(item, dict):
+                    result = item.get("result") or item.get("output") or item.get("content")
+
+                # If we have a tool invocation (name + args)
+                if isinstance(name, str) and name and isinstance(args, (dict, list)):
+                    # Normalize args to dict where possible
+                    norm_args: dict[str, Any]
+                    if isinstance(args, dict):
+                        norm_args = args
+                    else:
+                        # If args is a list or other type, coerce minimally
+                        norm_args = {"args": args}
+                    return ToolStepEvent(conversation_id=conversation_id, name=name, args=norm_args)
+
+                # If we have a tool result/completion
+                if isinstance(name, str) and name and result is not None:
+                    summary = self._summarize(result)
+                    return ToolStepEvent(
+                        conversation_id=conversation_id,
+                        name=name,
+                        args={},
+                        result_summary=summary,
+                    )
+
+            return None
+
+        # Ignore other event kinds for now
+        return None
+
+    @staticmethod
+    def _summarize(value: Any, *, limit: int = 200) -> str:
+        text = str(value)
+        return text if len(text) <= limit else text[: limit - 1] + "\u2026"
+
+
+__all__ = ["OpenAIAgentsRunner"]
+

--- a/magent2/worker/__main__.py
+++ b/magent2/worker/__main__.py
@@ -4,8 +4,6 @@ import os
 from collections.abc import Iterable
 from typing import Any
 
-from agents import Agent
-
 from magent2.bus.redis_adapter import RedisBus
 from magent2.models.envelope import BaseStreamEvent, MessageEnvelope, OutputEvent, TokenEvent
 from magent2.runner.config import load_config
@@ -22,6 +20,8 @@ class EchoRunner(Runner):
 def build_runner_from_env() -> Runner:
     cfg = load_config()
     if cfg.api_key:
+        from agents import Agent  # defer import to avoid issues in Echo mode
+
         agent = Agent(name=cfg.agent_name, instructions=cfg.instructions, model=cfg.model)
         return OpenAIAgentsRunner(agent)
     return EchoRunner()

--- a/magent2/worker/__main__.py
+++ b/magent2/worker/__main__.py
@@ -4,12 +4,13 @@ import os
 from collections.abc import Iterable
 from typing import Any
 
+from agents import Agent
+
 from magent2.bus.redis_adapter import RedisBus
 from magent2.models.envelope import BaseStreamEvent, MessageEnvelope, OutputEvent, TokenEvent
-from magent2.worker.worker import Runner, Worker
 from magent2.runner.config import load_config
 from magent2.runner.openai_agents_runner import OpenAIAgentsRunner
-from agents import Agent
+from magent2.worker.worker import Runner, Worker
 
 
 class EchoRunner(Runner):

--- a/magent2/worker/__main__.py
+++ b/magent2/worker/__main__.py
@@ -21,7 +21,7 @@ class EchoRunner(Runner):
 def build_runner_from_env() -> Runner:
     cfg = load_config()
     if cfg.api_key:
-        agent = Agent(name=cfg.agent_name, instructions=cfg.instructions)
+        agent = Agent(name=cfg.agent_name, instructions=cfg.instructions, model=cfg.model)
         return OpenAIAgentsRunner(agent)
     return EchoRunner()
 

--- a/magent2/worker/__main__.py
+++ b/magent2/worker/__main__.py
@@ -23,7 +23,9 @@ def build_runner_from_env() -> Runner:
         from agents import Agent  # defer import to avoid issues in Echo mode
 
         agent = Agent(name=cfg.agent_name, instructions=cfg.instructions, model=cfg.model)
+        print(f"[worker] runner=OpenAI agent={cfg.agent_name} model={cfg.model}")
         return OpenAIAgentsRunner(agent)
+    print(f"[worker] runner=Echo agent={cfg.agent_name}")
     return EchoRunner()
 
 

--- a/tests/test_runner_sdk.py
+++ b/tests/test_runner_sdk.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import types
+from typing import Any, Iterable
+
+import pytest
+
+from magent2.models.envelope import MessageEnvelope, OutputEvent, TokenEvent, ToolStepEvent
+
+
+class _FakeResultStream:
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+
+    async def stream_events(self):  # pragma: no cover - exercised via adapter
+        for ev in self._events:
+            yield ev
+
+
+class _FakeSDKRunner:
+    @staticmethod
+    def run_streamed(agent: Any, input: str, session: Any) -> _FakeResultStream:  # type: ignore[name-defined]
+        # The agent is unused in the fake; we only validate that our adapter calls this API shape
+        return _FakeResultStream(_FakeSDKRunner._next_events())
+
+    # patched per-test to supply events
+    _next_events: Any = staticmethod(lambda: [])
+
+
+def _patch_sdk_runner(monkeypatch: pytest.MonkeyPatch, events: list[Any]) -> None:
+    import magent2.runner.openai_agents_runner as oar
+
+    # Install the fake SDK Runner for this test
+    _FakeSDKRunner._next_events = staticmethod(lambda: list(events))
+    monkeypatch.setattr(oar, "SDKRunner", _FakeSDKRunner)
+
+
+def _make_event(ev_type: str, data: Any) -> Any:
+    return types.SimpleNamespace(type=ev_type, data=data)
+
+
+def test_adapter_maps_token_tool_and_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange SDK-like events
+    sdk_events = [
+        _make_event("raw_response_event", {"delta": "H"}),
+        _make_event("raw_response_event", {"delta": "i"}),
+        _make_event(
+            "run_item_stream_event",
+            {"name": "terminal.run", "args": {"cmd": "echo hi"}},
+        ),
+        _make_event(
+            "run_item_stream_event",
+            {"name": "terminal.run", "result": "ok"},
+        ),
+    ]
+    _patch_sdk_runner(monkeypatch, sdk_events)
+
+    # Build runner
+    from agents import Agent
+    from magent2.runner.openai_agents_runner import OpenAIAgentsRunner
+
+    agent = Agent(name="DevAgent", instructions="You are a helpful assistant.")
+    runner = OpenAIAgentsRunner(agent)
+
+    env = MessageEnvelope(
+        conversation_id="conv_test",
+        sender="user:test",
+        recipient="agent:DevAgent",
+        type="message",
+        content="hello",
+    )
+
+    # Act
+    out: list[Any] = list(runner.stream_run(env))
+
+    # Assert order and mapping
+    assert [e.event for e in out] == [
+        "token",
+        "token",
+        "tool_step",
+        "tool_step",
+        "output",
+    ]
+    assert isinstance(out[0], TokenEvent) and out[0].text == "H" and out[0].index == 0
+    assert isinstance(out[1], TokenEvent) and out[1].text == "i" and out[1].index == 1
+    assert isinstance(out[2], ToolStepEvent) and out[2].name == "terminal.run" and out[2].args == {"cmd": "echo hi"}
+    assert isinstance(out[3], ToolStepEvent) and out[3].name == "terminal.run" and out[3].result_summary == "ok"
+    assert isinstance(out[4], OutputEvent) and out[4].text == "Hi"
+
+
+def test_adapter_reuses_session_by_conversation(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Prepare a spy to capture session identities passed to SDK
+    seen_sessions: list[Any] = []
+
+    class _SpySDKRunner:
+        @staticmethod
+        def run_streamed(agent: Any, input: str, session: Any) -> _FakeResultStream:  # type: ignore[name-defined]
+            seen_sessions.append(session)
+            return _FakeResultStream([])
+
+    import magent2.runner.openai_agents_runner as oar
+
+    monkeypatch.setattr(oar, "SDKRunner", _SpySDKRunner)
+
+    from agents import Agent
+    from magent2.runner.openai_agents_runner import OpenAIAgentsRunner
+
+    agent = Agent(name="DevAgent", instructions="You are a helpful assistant.")
+    runner = OpenAIAgentsRunner(agent)
+
+    env = MessageEnvelope(
+        conversation_id="conv_same",
+        sender="user:test",
+        recipient="agent:DevAgent",
+        type="message",
+        content="hello",
+    )
+
+    # Run twice with the same conversation id
+    list(runner.stream_run(env))
+    list(runner.stream_run(env))
+
+    assert len(seen_sessions) == 2
+    assert seen_sessions[0] is seen_sessions[1]
+    # Also ensure only one session object is cached
+    assert getattr(runner, "_sessions") is not None
+    assert len(getattr(runner, "_sessions")) == 1
+

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,6 +4,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
+import pytest
+
 from magent2.bus.interface import Bus, BusMessage
 from magent2.models.envelope import (
     MessageEnvelope,
@@ -160,7 +162,7 @@ def test_worker_one_run_per_conversation() -> None:
     ]
 
 
-def test_runner_selection_by_env(monkeypatch):
+def test_runner_selection_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # Import helper after patching env each time
     import importlib
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -158,3 +158,22 @@ def test_worker_one_run_per_conversation() -> None:
         "token",
         "output",
     ]
+
+
+def test_runner_selection_by_env(monkeypatch):
+    # Import helper after patching env each time
+    import importlib
+
+    m = importlib.import_module("magent2.worker.__main__")
+
+    # Case 1: no API key -> EchoRunner
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    importlib.reload(m)
+    r1 = m.build_runner_from_env()
+    assert r1.__class__.__name__ == "EchoRunner"
+
+    # Case 2: api key set -> OpenAIAgentsRunner
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    importlib.reload(m)
+    r2 = m.build_runner_from_env()
+    assert r2.__class__.__name__ == "OpenAIAgentsRunner"


### PR DESCRIPTION
# Pull Request

## Summary

Implements an SDK-backed runner for OpenAI Agents, enabling the worker to interact with OpenAI's agent platform. This includes a new runner adapter, configuration loading from environment variables, and dynamic runner selection.

## Linked Issues

- Closes #33 (as per handover doc 33)

## Changes

- [ ] Major
- [x] Minor

## Tests

- [x] Unit tests added/updated
- [ ] Manual verification steps described

## Risk & Rollback

- Risk: Introduction of new dependencies and an asynchronous-to-synchronous bridging mechanism. Potential for new bugs in event mapping or session management.
- Rollback plan: Revert this PR. The `EchoRunner` remains the default if `OPENAI_API_KEY` is not set, providing a safe fallback.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest` (targeted tests passed)
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-a7eb709b-7e5a-4f85-82ba-79a6511417e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7eb709b-7e5a-4f85-82ba-79a6511417e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

