### PR TITLE
Execute handover document 37

### DIFF
--- a/magent2/tools/chat/__init__.py
+++ b/magent2/tools/chat/__init__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agents import function_tool
+
+from .function_tools import send_message as _send_message
+from .function_tools import set_bus_for_testing
+
+
+@function_tool
+def chat_send(recipient: str, content: str) -> dict[str, Any]:
+    """Send a chat message to a conversation or agent via Bus.
+
+    Args:
+        recipient: "chat:{conversation_id}" or "agent:{AgentName}".
+        content: Non-empty message text.
+
+    Returns:
+        {"ok": bool, "envelope_id": str, "published_to": list[str]}
+    """
+
+    return _send_message(recipient, content)
+
+
+__all__ = ["chat_send", "set_bus_for_testing"]
+

--- a/magent2/tools/chat/function_tools.py
+++ b/magent2/tools/chat/function_tools.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from magent2.bus.interface import Bus, BusMessage
+from magent2.models.envelope import MessageEnvelope
+
+
+_TEST_BUS: Bus | None = None
+
+
+def set_bus_for_testing(bus: Bus | None) -> None:
+    global _TEST_BUS
+    _TEST_BUS = bus
+
+
+def _get_bus() -> Bus:
+    if _TEST_BUS is not None:
+        return _TEST_BUS
+    # Lazy import to avoid hard dependency in tests
+    from magent2.bus.redis_adapter import RedisBus  # type: ignore
+
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    return RedisBus(url)
+
+
+def _resolve_sender() -> str:
+    name = os.getenv("AGENT_NAME", "").strip()
+    return f"agent:{name}" if name else "agent:unknown"
+
+
+def _resolve_conversation_id(
+    recipient: str, ctx: dict[str, Any] | None
+) -> str:
+    if recipient.startswith("chat:"):
+        cid = recipient.split(":", 1)[1]
+        if cid:
+            return cid
+    # For agent recipients, try context/env
+    if ctx is not None:
+        value = ctx.get("conversation_id")
+        cid_ctx = str(value).strip() if value is not None else ""
+        if cid_ctx:
+            return cid_ctx
+    cid_env = os.getenv("CHAT_TOOL_CONVERSATION_ID", "").strip()
+    if cid_env:
+        return cid_env
+    raise ValueError("conversation_id not available for agent recipient")
+
+
+def _build_envelope(
+    conversation_id: str, sender: str, recipient: str, content: str
+) -> MessageEnvelope:
+    return MessageEnvelope(
+        conversation_id=conversation_id,
+        sender=sender,
+        recipient=recipient,
+        type="message",
+        content=content,
+        metadata={},
+    )
+
+
+def _publish(bus: Bus, envelope: MessageEnvelope) -> list[str]:
+    payload = envelope.model_dump(mode="json")
+    topics: list[str] = []
+
+    conv_topic = f"chat:{envelope.conversation_id}"
+    bus.publish(conv_topic, BusMessage(topic=conv_topic, payload=payload))
+    topics.append(conv_topic)
+
+    if envelope.recipient.startswith("agent:"):
+        agent_name = envelope.recipient.split(":", 1)[1]
+        if agent_name:
+            agent_topic = f"chat:{agent_name}"
+            bus.publish(agent_topic, BusMessage(topic=agent_topic, payload=payload))
+            topics.append(agent_topic)
+
+    return topics
+
+
+def send_message(
+    recipient: str, content: str, *, context: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    rec = (recipient or "").strip()
+    if not rec or not (rec.startswith("chat:") or rec.startswith("agent:")):
+        raise ValueError("recipient must be 'chat:{conversation_id}' or 'agent:{Name}'")
+    text = (content or "").strip()
+    if not text:
+        raise ValueError("content must be non-empty")
+
+    conversation_id = _resolve_conversation_id(rec, context)
+    sender = _resolve_sender()
+    env = _build_envelope(conversation_id, sender, rec, text)
+
+    bus = _get_bus()
+    published_to = _publish(bus, env)
+    return {"ok": True, "envelope_id": env.id, "published_to": published_to}
+

--- a/tests/test_chat_function_tool.py
+++ b/tests/test_chat_function_tool.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+import pytest
+
+from magent2.bus.interface import Bus, BusMessage
+from magent2.tools.chat.function_tools import send_message, set_bus_for_testing
+
+
+class InMemoryBus(Bus):
+    def __init__(self) -> None:
+        self._topics: dict[str, list[BusMessage]] = {}
+
+    def publish(self, topic: str, message: BusMessage) -> str:
+        self._topics.setdefault(topic, []).append(message)
+        return message.id
+
+    def read(
+        self, topic: str, last_id: str | None = None, limit: int = 100
+    ) -> Iterable[BusMessage]:
+        items = self._topics.get(topic, [])
+        if last_id is None:
+            return list(items[-limit:])
+        start = 0
+        for i, m in enumerate(items):
+            if m.id == last_id:
+                start = i + 1
+                break
+        return list(items[start : start + limit])
+
+
+@pytest.fixture()
+def bus() -> InMemoryBus:
+    b = InMemoryBus()
+    set_bus_for_testing(b)
+    return b
+
+
+def _last_message(bus: InMemoryBus, topic: str) -> BusMessage:
+    messages = list(bus.read(topic, last_id=None, limit=1_000))
+    assert messages, "no messages on topic"
+    return messages[-1]
+
+
+def test_publish_to_conversation_topic_for_chat_recipient(bus: InMemoryBus, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Ensure deterministic sender
+    monkeypatch.setenv("AGENT_NAME", "Tester")
+
+    result = send_message("chat:conv1", "hello world")
+    assert result["ok"] is True
+    topics = result["published_to"]
+    assert topics == ["chat:conv1"]
+
+    last = _last_message(bus, "chat:conv1")
+    payload = last.payload
+    assert payload["conversation_id"] == "conv1"
+    assert payload["recipient"] == "chat:conv1"
+    assert payload["type"] == "message"
+    assert isinstance(payload["created_at"], str)
+
+
+def test_publish_to_conversation_and_agent_topics_for_agent_recipient(bus: InMemoryBus, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_NAME", "Tester")
+    monkeypatch.setenv("CHAT_TOOL_CONVERSATION_ID", "conv2")
+
+    result = send_message("agent:DevAgent", "ping")
+    assert result["ok"] is True
+    topics = result["published_to"]
+    assert set(topics) == {"chat:conv2", "chat:DevAgent"}
+
+    last_conv = _last_message(bus, "chat:conv2")
+    payload = last_conv.payload
+    assert payload["conversation_id"] == "conv2"
+    assert payload["recipient"] == "agent:DevAgent"
+
+    last_agent = _last_message(bus, "chat:DevAgent")
+    assert last_agent.payload == payload
+
+
+@pytest.mark.parametrize("bad_recipient", ["room:123", "agent:", "", " "])
+def test_invalid_recipient_raises_value_error(bus: InMemoryBus, bad_recipient: str) -> None:
+    with pytest.raises(ValueError):
+        send_message(bad_recipient, "hi")
+
+
+@pytest.mark.parametrize("bad_content", ["", " "])
+def test_blank_content_raises_value_error(bus: InMemoryBus, bad_content: str) -> None:
+    with pytest.raises(ValueError):
+        send_message("chat:convX", bad_content)
+


### PR DESCRIPTION
# Pull Request

## Summary

Implements a new `chat_send` function tool, enabling agents to publish messages to the bus for conversations or other agents, as specified in handover document #37.

## Linked Issues

- Closes #37

## Changes

- [ ] Major
- [x] Minor

## Tests

- [x] Unit tests added/updated
- [x] Manual verification steps described
  - Ran `uv run pytest tests/test_chat_function_tool.py` and confirmed all tests passed.

## Risk & Rollback

- Risk: Low. This is a new feature with dedicated tests and does not modify existing critical paths.
- Rollback plan: Revert this commit.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest`
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-e442f663-7fa6-4946-8451-1daf2a591eba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e442f663-7fa6-4946-8451-1daf2a591eba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

