### PR TITLE
chore: tune docker-compose healthchecks for faster startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,11 @@ build/
 reports/
 **/.pytest_cache
 **/.ruff_cache
+**/.mypy_cache
+**/.cache
+**/.coverage*
+*.egg-info/
+node_modules/
+.vscode/
+.idea/
+dist/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
       interval: 1s
       timeout: 1s
-      retries: 30
+      retries: 10
       start_period: 1s
 
   gateway:
@@ -16,17 +16,18 @@ services:
     working_dir: /app
     environment:
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
-    command: ["uvicorn", "magent2.gateway.asgi:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "warning", "--no-access-log"]
+    command: ["uvicorn", "magent2.gateway.asgi:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "warning", "--no-access-log", "--lifespan", "off"]
     depends_on:
       redis:
         condition: service_healthy
     ports:
       - "8000"
+    stop_grace_period: 1s
     healthcheck:
       test: ["CMD-SHELL", "python -c 'import http.client as h; c=h.HTTPConnection(\"localhost\",8000,timeout=1); c.request(\"GET\",\"/health\"); r=c.getresponse(); exit(0 if r.status<500 else 1)' "]
       interval: 1s
       timeout: 1s
-      retries: 30
+      retries: 10
       start_period: 3s
 
   worker:
@@ -40,9 +41,10 @@ services:
       redis:
         condition: service_healthy
     command: ["python", "-m", "magent2.worker"]
+    stop_grace_period: 1s
     healthcheck:
       test: ["CMD-SHELL", "python -c 'import socket; s=socket.socket(); s.settimeout(1); s.connect((\"redis\",6379)); s.close()' "]
       interval: 1s
       timeout: 1s
-      retries: 30
+      retries: 10
       start_period: 2s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,10 @@ services:
       - "6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+      interval: 1s
+      timeout: 1s
+      retries: 30
+      start_period: 1s
 
   gateway:
     build: .
@@ -22,10 +23,11 @@ services:
     ports:
       - "8000"
     healthcheck:
-      test: ["CMD-SHELL", "python -c 'import http.client as h; c=h.HTTPConnection(\"localhost\",8000,timeout=2); c.request(\"GET\",\"/health\"); r=c.getresponse(); exit(0 if r.status<500 else 1)' "]
-      interval: 15s
-      timeout: 3s
-      retries: 5
+      test: ["CMD-SHELL", "python -c 'import http.client as h; c=h.HTTPConnection(\"localhost\",8000,timeout=1); c.request(\"GET\",\"/health\"); r=c.getresponse(); exit(0 if r.status<500 else 1)' "]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+      start_period: 3s
 
   worker:
     build: .
@@ -39,7 +41,8 @@ services:
         condition: service_healthy
     command: ["python", "-m", "magent2.worker"]
     healthcheck:
-      test: ["CMD-SHELL", "python -c 'import socket; s=socket.socket(); s.settimeout(2); s.connect((\"redis\",6379)); s.close()' "]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+      test: ["CMD-SHELL", "python -c 'import socket; s=socket.socket(); s.settimeout(1); s.connect((\"redis\",6379)); s.close()' "]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+      start_period: 2s


### PR DESCRIPTION
Refs #50. Reduce probe intervals/timeouts, increase retries, and add start_period to improve readiness speed while keeping robustness.