### PR TITLE
Read and execute handover doc 41

### DIFF
--- a/magent2/tools/terminal/tool.py
+++ b/magent2/tools/terminal/tool.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import signal
 import time
 from pathlib import Path
 from subprocess import DEVNULL, PIPE, Popen, TimeoutExpired
-from typing import Any
+from typing import Any, Iterable
 
 
 def _truncate_to_bytes(text: str, limit_bytes: int) -> tuple[str, bool]:
@@ -39,11 +40,24 @@ class TerminalTool:
         timeout_seconds: float = 5.0,
         output_cap_bytes: int = 8_192,
         extra_env: dict[str, str] | None = None,
+        deny_commands: list[str] | None = None,
+        sandbox_cwd: str | None = None,
     ) -> None:
         self.allowed_commands: list[str] = allowed_commands or []
         self.timeout_seconds: float = timeout_seconds
         self.output_cap_bytes: int = output_cap_bytes
         self.extra_env: dict[str, str] = extra_env or {}
+        # Policy from args or environment
+        env_deny = os.getenv("TERMINAL_DENY_COMMANDS", "").strip()
+        self.deny_command_prefixes: list[str] = (
+            [s for s in (p.strip() for p in env_deny.split(",")) if s]
+            if deny_commands is None
+            else deny_commands
+        )
+        env_sandbox = os.getenv("TERMINAL_SANDBOX_CWD")
+        self._sandbox_root: Path | None = (
+            Path(sandbox_cwd).resolve() if sandbox_cwd is not None else (Path(env_sandbox).resolve() if env_sandbox else None)
+        )
 
     def _sanitize_env(self) -> dict[str, str]:
         # Minimal, deterministic environment
@@ -65,14 +79,56 @@ class TerminalTool:
         if cmd not in self.allowed_commands:
             raise PermissionError(f"Command '{cmd}' is not allowed")
 
+    def _assert_not_denied(self, command: str) -> None:
+        if not self.deny_command_prefixes:
+            return
+        tokens = shlex.split(command)
+        if not tokens:
+            raise ValueError("Empty command")
+        raw = tokens[0]
+        cmd = os.path.basename(raw)
+        for prefix in self.deny_command_prefixes:
+            if cmd.startswith(prefix) or raw.startswith(prefix):
+                raise PermissionError(f"Command '{cmd}' is denied by policy")
+
+    def _resolve_working_dir(self, cwd: str | None) -> str | None:
+        # Enforce sandbox when configured
+        if self._sandbox_root is None:
+            if cwd is None:
+                return None
+            return str(Path(cwd))
+
+        sandbox_root = self._sandbox_root
+        assert sandbox_root is not None
+
+        if cwd is None or str(cwd).strip() == "":
+            resolved = sandbox_root
+        else:
+            given = Path(cwd)
+            candidate = given.resolve() if given.is_absolute() else (sandbox_root / given).resolve()
+            # Ensure candidate is under sandbox_root
+            try:
+                _ = candidate.relative_to(sandbox_root)
+            except Exception:
+                raise PermissionError("Working directory escapes sandbox root")
+            resolved = candidate
+
+        return str(resolved)
+
+    @staticmethod
+    def _redact_output(text: str, patterns: Iterable[re.Pattern[str]] | None = None) -> str:
+        secret_patterns: list[re.Pattern[str]] = [
+            re.compile(r"sk-[A-Za-z0-9]{6,}"),
+        ]
+        for pat in (patterns or secret_patterns):
+            text = pat.sub("[REDACTED]", text)
+        return text
+
     def run(self, command: str, cwd: str | None = None) -> dict[str, Any]:
+        self._assert_not_denied(command)
         self._assert_allowed(command)
 
-        working_dir: str | None
-        if cwd is None:
-            working_dir = None
-        else:
-            working_dir = str(Path(cwd))
+        working_dir = self._resolve_working_dir(cwd)
 
         env = self._sanitize_env()
 
@@ -110,7 +166,9 @@ class TerminalTool:
                 combined += "\n"
             combined += stderr
 
-        out_text, was_truncated = _truncate_to_bytes(combined, self.output_cap_bytes)
+        # Redact sensitive tokens prior to truncation
+        redacted = self._redact_output(combined)
+        out_text, was_truncated = _truncate_to_bytes(redacted, self.output_cap_bytes)
 
         result: dict[str, Any] = {
             "ok": (proc.returncode == 0) and not timeout,

--- a/tests/test_terminal_safety.py
+++ b/tests/test_terminal_safety.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from magent2.tools.terminal.tool import TerminalTool
+
+
+def test_denylist_blocks_even_if_allowlisted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERMINAL_DENY_COMMANDS", "rm")
+    tool = TerminalTool(allowed_commands=["rm", "echo"])  # allowed but should still be denied
+    with pytest.raises(PermissionError):
+        tool.run("rm -rf /tmp")
+
+
+def test_sandbox_cwd_enforced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sandbox = tmp_path / "sb"
+    outside = tmp_path / "outside"
+    sandbox.mkdir()
+    outside.mkdir()
+    (sandbox / "file.txt").write_text("hi")
+    monkeypatch.setenv("TERMINAL_SANDBOX_CWD", str(sandbox))
+    tool = TerminalTool(allowed_commands=["bash", "cat", "echo"]) 
+
+    # Default cwd should be sandbox root
+    result = tool.run("bash -lc 'pwd' ")
+    assert result["ok"] is True
+    assert str(sandbox) in result["stdout"].strip()
+
+    # Relative path within sandbox OK
+    result2 = tool.run("bash -lc 'test -f file.txt && echo ok'", cwd=".")
+    assert result2["ok"] is True
+    assert "ok" in result2["stdout"]
+
+    # Escaping attempts should be blocked
+    with pytest.raises(PermissionError):
+        tool.run("bash -lc 'pwd'", cwd="../outside")
+
+    # Absolute path outside sandbox should be blocked
+    with pytest.raises(PermissionError):
+        tool.run("bash -lc 'pwd'", cwd=str(outside))
+
+
+def test_redaction_of_secrets(tmp_path: Path) -> None:
+    tool = TerminalTool(allowed_commands=["bash"]) 
+    fake_secret = "sk-abc1234567890"
+    result = tool.run(f"bash -lc 'echo {fake_secret} && echo {fake_secret} 1>&2'")
+    assert result["ok"] is True
+    assert fake_secret not in result["stdout"]
+    assert "[REDACTED]" in result["stdout"]
+


### PR DESCRIPTION
# Pull Request

## Summary

Implements terminal safety hardening measures as specified in handover document #41. This includes adding a command deny-list, enforcing a working directory sandbox, and redacting sensitive information (e.g., API keys) from terminal output. This enhances the security and control over executed commands.

## Linked Issues

- Closes #41

## Changes

- [x] Major
- [ ] Minor

## Tests

- [x] Unit tests added/updated
- [ ] Manual verification steps described

## Risk & Rollback

- Risk: Potential for legitimate commands to be inadvertently blocked by the deny-list or for valid working directories to be restricted by the sandbox.
- Rollback plan: Revert this pull request.

## Checklist

- [x] References at least one GitHub issue
- [ ] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest`
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-8b9c000c-7310-4b7b-822a-7873225e38b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b9c000c-7310-4b7b-822a-7873225e38b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

