### PR TITLE
Read agents doc and pick up issue 114

### DIFF
--- a/magent2/bus/redis_adapter.py
+++ b/magent2/bus/redis_adapter.py
@@ -45,6 +45,14 @@ class RedisBus(Bus):
     # ----------------------------
     # Public API
     # ----------------------------
+    def get_client(self) -> Any:
+        """Return the underlying Redis client object.
+
+        Exposed for advanced use cases such as idempotency sets or short-lived
+        locks that are orthogonal to the Bus publish/read semantics.
+        """
+        return self._redis
+
     def publish(self, topic: str, message: BusMessage) -> str:  # noqa: D401
         """Append one message to a topic. Returns the Bus message id (uuid)."""
         # Store canonical id and payload JSON in the stream entry

--- a/magent2/worker/worker.py
+++ b/magent2/worker/worker.py
@@ -211,7 +211,8 @@ class Worker:
             from magent2.bus.redis_adapter import RedisBus  # local import to avoid hard dep
 
             if isinstance(self._bus, RedisBus):
-                return self._bus._redis
+                # Use public API to avoid private attribute access
+                return self._bus.get_client()
         except Exception:
             return None
         return None


### PR DESCRIPTION
# Pull Request

## Summary

This PR introduces a public `get_client()` method to the `RedisBus` class, allowing external components to access the underlying Redis client directly for advanced use cases. The `Worker` class has been refactored to utilize this new public API instead of directly accessing the private `_redis` attribute of `RedisBus`, improving encapsulation and maintainability.

## Linked Issues

- Closes #114

## Changes

- [ ] Major
- [x] Minor

## Tests

- [x] Unit tests added/updated (Existing tests cover the refactored `Worker` behavior)
- [ ] Manual verification steps described

## Risk & Rollback

- Risk: Low. This is a refactoring that exposes an existing internal client via a public method. The core functionality remains unchanged.
- Rollback plan: Revert the commit.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest`
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-c8da0238-17c2-4b1c-b56e-0a1d9967e38b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8da0238-17c2-4b1c-b56e-0a1d9967e38b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>