### PR TITLE
Read agents.md and pick up issue 115

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,13 +22,13 @@ services:
         condition: service_healthy
     ports:
       - "8000"
-    stop_grace_period: 1s
+    stop_grace_period: 15s
     healthcheck:
-      test: ["CMD-SHELL", "python -c 'import http.client as h; c=h.HTTPConnection(\"localhost\",8000,timeout=1); c.request(\"GET\",\"/health\"); r=c.getresponse(); exit(0 if r.status<500 else 1)' "]
+      test: ["CMD-SHELL", "python -c 'import http.client as h; c=h.HTTPConnection(\"localhost\",8000,timeout=3); c.request(\"GET\",\"/health\"); r=c.getresponse(); exit(0 if r.status<500 else 1)' "]
       interval: 10s
-      timeout: 1s
-      retries: 3
-      start_period: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
 
   worker:
     build: .
@@ -46,10 +46,10 @@ services:
       redis:
         condition: service_healthy
     command: ["python", "-m", "magent2.worker"]
-    stop_grace_period: 1s
+    stop_grace_period: 30s
     healthcheck:
-      test: ["CMD-SHELL", "python -c 'import socket; s=socket.socket(); s.settimeout(1); s.connect((\"redis\",6379)); s.close()' "]
+      test: ["CMD-SHELL", "python -c 'import socket; s=socket.socket(); s.settimeout(2); s.connect((\"redis\",6379)); s.close()' "]
       interval: 10s
-      timeout: 1s
-      retries: 3
-      start_period: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s


### PR DESCRIPTION
# Pull Request

## Summary

This PR updates `docker-compose.yml` to improve the robustness and reliability of the `gateway` and `worker` services. It increases `stop_grace_period` for graceful shutdowns and relaxes healthcheck parameters (timeouts, retries, start periods) to reduce flakiness in local development and CI environments.

## Linked Issues

- Closes #115

## Changes

- [ ] Major
- [x] Minor

## Tests

- [ ] Unit tests added/updated
- [x] Manual verification steps described
  - Ran `just check` locally, which includes linting, formatting, and tests. All quality gates passed.
  - Verified that `docker compose up` and `docker compose down` operations are more stable and less prone to premature service termination or unhealthy states.

## Risk & Rollback

- Risk: Slightly slower detection of actual service failures and potentially slower `docker compose down` operations due to increased grace periods and healthcheck timeouts.
- Rollback plan: Revert this commit.

## Checklist

- [x] References at least one GitHub issue
- [x] `pre-commit` passed on staged files
- [x] Tests pass: `uv run pytest` (verified via `just check`)
- [ ] Docs updated (README or `docs/*`)

---
<a href="https://cursor.com/background-agent?bcId=bc-42347338-1d58-40c7-a327-3d045352bbb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42347338-1d58-40c7-a327-3d045352bbb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>